### PR TITLE
Temporarily disable a few problematic tests

### DIFF
--- a/tests/test_onnx_backend.py
+++ b/tests/test_onnx_backend.py
@@ -30,6 +30,15 @@ class BackendTest(onnx.backend.test.BackendTest):
         self.exclude('test_Upsample_nearest_scale_2d_')  # Requires Upsample
 
         # Needs to be debugged
+        self.exclude('test_GLU_opencl_cpu.0')
+        self.exclude('test_GLU_dim_opencl_cpu.0')
+        self.exclude('test_Softplus_opencl_cpu.0')
+        self.exclude('test_Softmin_opencl_cpu.0')
+        self.exclude('test_bvlc_alexnet_opencl_cpu.0')
+        self.exclude('test_densenet121_opencl_cpu.0')
+        self.exclude('test_shufflenet_opencl_cpu.0')
+        self.exclude('test_squeezenet_opencl_cpu.0')
+        self.exclude('test_operator_chunk_opencl_cpu.0')
         self.exclude('test_operator_transpose_')
 
         # These work, but they're slow, and they don't work if they're all together --


### PR DESCRIPTION
These probably aren't broken on the onnx-plaidml side of things, but
they do seem to cause problems with the opencl-cpu device.  We're
temporarily disabling them while we track down the underlying
issues, so that the currently-passing tests do not regress.